### PR TITLE
Fix Image GPT

### DIFF
--- a/pl_bolts/models/vision/image_gpt/gpt2.py
+++ b/pl_bolts/models/vision/image_gpt/gpt2.py
@@ -29,13 +29,13 @@ class Block(nn.Module):
 
 class GPT2(pl.LightningModule):
     def __init__(
-            self,
-            embed_dim: int,
-            heads: int,
-            layers: int,
-            num_positions: int,
-            vocab_size: int,
-            num_classes: int
+        self,
+        embed_dim: int,
+        heads: int,
+        layers: int,
+        num_positions: int,
+        vocab_size: int,
+        num_classes: int,
     ):
         """
         GPT-2 from `language Models are Unsupervised Multitask Learners <https://d4mucfpksywv.cloudfront.net/
@@ -55,7 +55,7 @@ class GPT2(pl.LightningModule):
             batch_size = 32
             vocab_size = 16
             x = torch.randint(0, vocab_size, (seq_len, batch_size))
-            model = GPT2(embed_dim=32, heads=2, layers=2, num_positions=2, vocab_size=vocab_size, num_classes=4)
+            model = GPT2(embed_dim=32, heads=2, layers=2, num_positions=seq_len, vocab_size=vocab_size, num_classes=4)
             results = model(x)
         """
         super(GPT2, self).__init__()
@@ -70,8 +70,12 @@ class GPT2(pl.LightningModule):
         nn.init.normal_(self.sos)
 
     def _init_embeddings(self):
-        self.token_embeddings = nn.Embedding(self.hparams.vocab_size, self.hparams.embed_dim)
-        self.position_embeddings = nn.Embedding(self.hparams.num_positions, self.hparams.embed_dim)
+        self.token_embeddings = nn.Embedding(
+            self.hparams.vocab_size, self.hparams.embed_dim
+        )
+        self.position_embeddings = nn.Embedding(
+            self.hparams.num_positions, self.hparams.embed_dim
+        )
 
     def _init_layers(self):
         self.layers = nn.ModuleList()
@@ -79,7 +83,9 @@ class GPT2(pl.LightningModule):
             self.layers.append(Block(self.hparams.embed_dim, self.hparams.heads))
 
         self.ln_f = nn.LayerNorm(self.hparams.embed_dim)
-        self.head = nn.Linear(self.hparams.embed_dim, self.hparams.vocab_size, bias=False)
+        self.head = nn.Linear(
+            self.hparams.embed_dim, self.hparams.vocab_size, bias=False
+        )
         self.clf_head = nn.Linear(self.hparams.embed_dim, self.hparams.num_classes)
 
     def forward(self, x, classify=False):

--- a/pl_bolts/models/vision/image_gpt/igpt_module.py
+++ b/pl_bolts/models/vision/image_gpt/igpt_module.py
@@ -171,8 +171,6 @@ class ImageGPT(pl.LightningModule):
         # This only works with 1 channel images; something like KNN needs to be used
         # for RGB. Assumes data is in [0.0, 1.0].
         x = torch.round(x * (self.hparams.vocab_size - 1)).long()
-        self.print(x.max())
-        # test
 
         return self.gpt(x, classify)
 

--- a/tests/models/test_vision_models.py
+++ b/tests/models/test_vision_models.py
@@ -9,13 +9,17 @@ def test_igpt(tmpdir):
     dm = MNISTDataModule(tmpdir, normalize=False)
     model = ImageGPT(datamodule=dm)
 
-    trainer = pl.Trainer(limit_train_batches=2, limit_val_batches=2, limit_test_batches=2, max_epochs=1)
+    trainer = pl.Trainer(
+        limit_train_batches=2, limit_val_batches=2, limit_test_batches=2, max_epochs=1
+    )
     trainer.fit(model)
     trainer.test()
-    assert trainer.callback_metrics['test_loss'] < 1.7
+    assert trainer.callback_metrics["test_loss"] < 1.7
 
     model = ImageGPT(classify=True)
-    trainer = pl.Trainer(limit_train_batches=2, limit_val_batches=2, limit_test_batches=2, max_epochs=1)
+    trainer = pl.Trainer(
+        limit_train_batches=2, limit_val_batches=2, limit_test_batches=2, max_epochs=1
+    )
     trainer.fit(model)
 
 
@@ -23,8 +27,15 @@ def test_gpt2(tmpdir):
 
     seq_len = 17
     batch_size = 32
-    classes = 10
-    x = torch.randint(0, 10, (seq_len, batch_size))
+    vocab_size = 16
+    x = torch.randint(0, vocab_size, (seq_len, batch_size))
 
-    model = GPT2(embed_dim=16, heads=2, layers=2, num_positions=28 * 28, vocab_size=16, num_classes=classes)
+    model = GPT2(
+        embed_dim=16,
+        heads=2,
+        layers=2,
+        num_positions=seq_len,
+        vocab_size=vocab_size,
+        num_classes=10,
+    )
     model(x)


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?
Fixes Image GPT. Images were not being properly quantized before. See [code](https://github.com/teddykoker/pytorch-lightning-bolts/blob/17048c6a3db1267f05c07e5ab461e1bf84f380e6/pl_bolts/models/vision/image_gpt/igpt_module.py#L170-L173):
```python
    def forward(self, x, classify=False):
        x = _shape_input(x)

        # TODO(teddykoker): this is a hack to quantize images into `vocab_size` bins.
        # This only works with 1 channel images; something like KNN needs to be used
        # for RGB. Assumes data is in [0.0, 1.0].
        x = torch.round(x * (self.hparams.vocab_size - 1)).long()

        return self.gpt(x, classify)
```

Also fixes docs.

## Review
@williamFalcon 

## Discussion
Implementing KNN for image quantization is fairly straight forward. I would be willing to implement at some point. But I am unsure where this code would go as is it is an independent preprocessing step that just needs to be run once (in practice I would just create my own dataset for the new quantized images).