### PR TITLE
Fixed the unused train/val/test Mnist transforms

### DIFF
--- a/pl_bolts/datamodules/fashion_mnist_datamodule.py
+++ b/pl_bolts/datamodules/fashion_mnist_datamodule.py
@@ -67,8 +67,7 @@ class FashionMNISTDataModule(LightningDataModule):
             batch_size: size of batch
             transforms: custom transforms
         """
-        if transforms is None:
-            transforms = self._default_transforms()
+        transforms = transforms or self.train_transforms or self._default_transforms()
 
         dataset = FashionMNIST(self.data_dir, train=True, download=False, transform=transforms)
         train_length = len(dataset)
@@ -91,8 +90,7 @@ class FashionMNISTDataModule(LightningDataModule):
             batch_size: size of batch
             transforms: custom transforms
         """
-        if transforms is None:
-            transforms = self._default_transforms()
+        transforms = transforms or self.valid_transforms or self._default_transforms()
 
         dataset = FashionMNIST(self.data_dir, train=True, download=True, transform=transforms)
         train_length = len(dataset)
@@ -115,8 +113,7 @@ class FashionMNISTDataModule(LightningDataModule):
             batch_size: size of batch
             transforms: custom transforms
         """
-        if transforms is None:
-            transforms = self._default_transforms()
+        transforms = transforms or self.test_transforms or self._default_transforms()
 
         dataset = FashionMNIST(self.data_dir, train=False, download=False, transform=transforms)
         loader = DataLoader(

--- a/pl_bolts/datamodules/fashion_mnist_datamodule.py
+++ b/pl_bolts/datamodules/fashion_mnist_datamodule.py
@@ -90,7 +90,7 @@ class FashionMNISTDataModule(LightningDataModule):
             batch_size: size of batch
             transforms: custom transforms
         """
-        transforms = transforms or self.valid_transforms or self._default_transforms()
+        transforms = transforms or self.val_transforms or self._default_transforms()
 
         dataset = FashionMNIST(self.data_dir, train=True, download=True, transform=transforms)
         train_length = len(dataset)

--- a/pl_bolts/datamodules/mnist_datamodule.py
+++ b/pl_bolts/datamodules/mnist_datamodule.py
@@ -70,8 +70,7 @@ class MNISTDataModule(LightningDataModule):
             batch_size: size of batch
             transforms: custom transforms
         """
-        if transforms is None:
-            transforms = self._default_transforms()
+        transforms = transforms or self.train_transforms or self._default_transforms()
 
         dataset = MNIST(self.data_dir, train=True, download=False, transform=transforms)
         train_length = len(dataset)
@@ -94,9 +93,7 @@ class MNISTDataModule(LightningDataModule):
             batch_size: size of batch
             transforms: custom transforms
         """
-        if transforms is None:
-            transforms = self._default_transforms()
-
+        transforms = transforms or self.val_transforms or self._default_transforms()
         dataset = MNIST(self.data_dir, train=True, download=True, transform=transforms)
         train_length = len(dataset)
         _, dataset_val = random_split(dataset, [train_length - self.val_split, self.val_split])
@@ -118,8 +115,7 @@ class MNISTDataModule(LightningDataModule):
             batch_size: size of batch
             transforms: custom transforms
         """
-        if transforms is None:
-            transforms = self._default_transforms()
+        transforms = transforms or self.val_transforms or self._default_transforms()
 
         dataset = MNIST(self.data_dir, train=False, download=False, transform=transforms)
         loader = DataLoader(


### PR DESCRIPTION
When the 'transforms' arg of the [train|val|test]_dataloader method is None,
The MNISTDataModule would use self._default_transforms(), ignoring the value
of `self.[train|val|test]_transforms`.

I changed this to use instead either:
1. `transform` arg to `xxxx_dataloader`, if passed;
2. `self.xxxx_transform`, if set;
3. `self._default_transforms()`.

Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes # (issue).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
