### PR TITLE
Fix doc for `pl_bolts.models.autoencoders.AE`

### DIFF
--- a/pl_bolts/models/autoencoders/basic_ae/basic_ae_module.py
+++ b/pl_bolts/models/autoencoders/basic_ae/basic_ae_module.py
@@ -26,7 +26,7 @@ class AE(LightningModule):
             **kwargs
     ):
         """
-        Arg:
+        Args:
 
             datamodule: the datamodule (train, val, test splits)
             input_channels: num of image channels


### PR DESCRIPTION
In current version of [doc for `pl_bolts.models.autoencoders.AE`](https://pytorch-lightning-bolts.readthedocs.io/en/latest/autoencoders.html#basic-ae), parameters section is not correctly rendered. This PR fixes the problem.