### PR TITLE
Fix max_depth recursion crash in AsynchronousLoader

### DIFF
--- a/pl_bolts/datamodules/async_dataloader.py
+++ b/pl_bolts/datamodules/async_dataloader.py
@@ -8,7 +8,6 @@ from torch.utils.data import DataLoader
 from torch.utils.data import Dataset
 from torch._six import container_abcs, string_classes, int_classes
 
-
 class AsynchronousLoader(object):
     """
     Class for asynchronously loading from CPU memory to device memory with DataLoader.
@@ -39,8 +38,7 @@ class AsynchronousLoader(object):
         elif hasattr(self.dataloader, '__len__'):
             self.num_batches = len(self.dataloader)
         else:
-            raise Exception(
-                "num_batches must be specified or data must have finite __len__")
+            raise Exception("num_batches must be specified or data must have finite __len__")
 
         self.device = device
         self.q_size = q_size
@@ -78,10 +76,10 @@ class AsynchronousLoader(object):
             return {key: self.load_instance(sample[key]) for key in sample}
         elif isinstance(sample, tuple) and hasattr(sample, '_fields'):  # namedtuple
             return elem_type(*(self.load_instance(d) for d in sample))
-        elif isinstance(sample, string_classes):
-            return sample
-        else:
+        elif isinstance(sample, container_abcs.Sequence) and not isinstance(sample, string_classes):
             return [self.load_instance(s) for s in sample]
+        else:
+            return sample
 
     def __iter__(self):
         # We don't want to run the thread more than once

--- a/pl_bolts/datamodules/async_dataloader.py
+++ b/pl_bolts/datamodules/async_dataloader.py
@@ -8,6 +8,7 @@ from torch.utils.data import DataLoader
 from torch.utils.data import Dataset
 from torch._six import container_abcs, string_classes, int_classes
 
+
 class AsynchronousLoader(object):
     """
     Class for asynchronously loading from CPU memory to device memory with DataLoader.
@@ -38,7 +39,8 @@ class AsynchronousLoader(object):
         elif hasattr(self.dataloader, '__len__'):
             self.num_batches = len(self.dataloader)
         else:
-            raise Exception("num_batches must be specified or data must have finite __len__")
+            raise Exception(
+                "num_batches must be specified or data must have finite __len__")
 
         self.device = device
         self.q_size = q_size
@@ -76,10 +78,10 @@ class AsynchronousLoader(object):
             return {key: self.load_instance(sample[key]) for key in sample}
         elif isinstance(sample, tuple) and hasattr(sample, '_fields'):  # namedtuple
             return elem_type(*(self.load_instance(d) for d in sample))
-        elif isinstance(sample, container_abcs.Sequence) and not isinstance(sample, string_classes):
-            return [self.load_instance(s) for s in sample]
-        else:
+        elif isinstance(sample, string_classes):
             return sample
+        else:
+            return [self.load_instance(s) for s in sample]
 
     def __iter__(self):
         # We don't want to run the thread more than once

--- a/pl_bolts/datamodules/async_dataloader.py
+++ b/pl_bolts/datamodules/async_dataloader.py
@@ -8,6 +8,7 @@ from torch.utils.data import DataLoader
 from torch.utils.data import Dataset
 from torch._six import container_abcs, string_classes, int_classes
 
+
 class AsynchronousLoader(object):
     """
     Class for asynchronously loading from CPU memory to device memory with DataLoader.
@@ -15,7 +16,7 @@ class AsynchronousLoader(object):
     Note that this only works for single GPU training, multiGPU uses PyTorch's DataParallel or
     DistributedDataParallel which uses its own code for transferring data across GPUs. This could just
     break or make things slower with DataParallel or DistributedDataParallel.
-
+    
     Args:
         data: The PyTorch Dataset or DataLoader we're using to load.
         device: The PyTorch device we are loading to


### PR DESCRIPTION
Some people use dict samples with strings, numpy array etc. They are returned from dataloader and are passed to model. Later those are parsed/replaced/removed inside of step/forward function.

Example of such dict (I use it):
`{'image': tensor([WHATEVER]), 'path': [WHATEVER_STRING], 'target': tensor([WHATEVER_NUMPY]), 'meta': {'PatientAge': tensor([WHATEVER]), 'PatientSex': tensor([WHATEVER]), 'StudyDate': tensor([WHATEVER])}, 'mask': tensor([WHATEVER]), 'bboxes': [[tensor([WHATEVER]), tensor([WHATEVER]), tensor([WHATEVER])]]}`

Sadly, async loader was crashing as max depth of recursion was reached (e.g. when it meets string, it just infinitely goes to else in original AsyncLoader). 

**I went to torch.utils.data.default_collate (as it's said that code is based on it), took few lines from there and it works now.** :) 

So it will no longer crash at named_tuples, dict-like objects and strings. Those will all be processed.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   (no need, it's just a small bugfix)
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes issue when anything other than torch.tensor containing thing is passed to AsynchronousLoader (more details above)

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
