### PR TITLE
Explicitly chain exceptions with `raise ... from ...`

### DIFF
--- a/pl_bolts/callbacks/vision/confused_logit.py
+++ b/pl_bolts/callbacks/vision/confused_logit.py
@@ -64,12 +64,12 @@ class ConfusedLogitCallback(Callback):  # pragma: no-cover
         x, y = batch
         try:
             logits = pl_module.last_logits
-        except AttributeError as e:
+        except AttributeError as err:
             m = """please track the last_logits in the training_step like so:
                 def training_step(...):
                     self.last_logits = your_logits
             """
-            raise AttributeError(m)
+            raise AttributeError(m) from err
 
         # only check when it has opinions (ie: the logit > 5)
         if logits.max() > self.min_logit_value:

--- a/pl_bolts/datamodules/base_dataset.py
+++ b/pl_bolts/datamodules/base_dataset.py
@@ -54,5 +54,5 @@ class LightDataset(ABC, Dataset):
         fpath = os.path.join(data_folder, file_name)
         try:
             urllib.request.urlretrieve(url, fpath)
-        except HTTPError:
-            raise RuntimeError(f'Failed download from {url}')
+        except HTTPError as err:
+            raise RuntimeError(f'Failed download from {url}') from err

--- a/pl_bolts/datamodules/imagenet_dataset.py
+++ b/pl_bolts/datamodules/imagenet_dataset.py
@@ -20,10 +20,10 @@ except ModuleNotFoundError:
 try:
     from torchvision.datasets import ImageNet
     from torchvision.datasets.imagenet import load_meta_file
-except ModuleNotFoundError:
+except ModuleNotFoundError as err:
     raise ModuleNotFoundError(  # pragma: no-cover
         'You want to use `torchvision` which is not installed yet, install it with `pip install torchvision`.'
-    )
+    ) from err
 
 
 class UnlabeledImagenet(ImageNet):

--- a/pl_bolts/datamodules/mnist_dataset.py
+++ b/pl_bolts/datamodules/mnist_dataset.py
@@ -3,10 +3,10 @@ from warnings import warn
 try:
     from torchvision import transforms as transform_lib
     from torchvision.datasets import MNIST
-except ModuleNotFoundError:
+except ModuleNotFoundError as err:
     raise ModuleNotFoundError(  # pragma: no-cover
         'You want to use `torchvision` which is not installed yet, install it with `pip install torchvision`.'
-    )
+    ) from err
 
 try:
     from PIL import Image

--- a/pl_bolts/models/regression/linear_regression.py
+++ b/pl_bolts/models/regression/linear_regression.py
@@ -126,10 +126,10 @@ def cli_main():
     # create dataset
     try:
         from sklearn.datasets import load_boston
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as err:
         raise ModuleNotFoundError(  # pragma: no-cover
             'You want to use `sklearn` which is not installed yet, install it with `pip install sklearn`.'
-        )
+        ) from err
 
     X, y = load_boston(return_X_y=True)  # these are numpy arrays
     loaders = SklearnDataModule(X, y)

--- a/pl_bolts/models/regression/logistic_regression.py
+++ b/pl_bolts/models/regression/logistic_regression.py
@@ -132,10 +132,10 @@ def cli_main():
     # Example: Iris dataset in Sklearn (4 features, 3 class labels)
     try:
         from sklearn.datasets import load_iris
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as err:
         raise ModuleNotFoundError(  # pragma: no-cover
             'You want to use `sklearn` which is not installed yet, install it with `pip install sklearn`.'
-        )
+        ) from err
 
     X, y = load_iris(return_X_y=True)
     loaders = SklearnDataModule(X, y)

--- a/pl_bolts/models/self_supervised/cpc/cpc_module.py
+++ b/pl_bolts/models/self_supervised/cpc/cpc_module.py
@@ -168,10 +168,10 @@ class CPCV2(pl.LightningModule):
     def shared_step(self, batch):
         try:
             from pl_bolts.datamodules.stl10_datamodule import STL10DataModule
-        except ModuleNotFoundError:
+        except ModuleNotFoundError as err:
             raise ModuleNotFoundError(  # pragma: no-cover
                 'You want to use `torchvision` which is not installed yet, install it with `pip install torchvision`.'
-            )
+            ) from err
 
         if isinstance(self.datamodule, STL10DataModule):
             unlabeled_batch = batch[0]


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
I'd like to suggest a fix in the way that Python 3's exception chaining is used. I recently submitted a PR and got it merged into PyTorchLightning at https://github.com/PyTorchLightning/pytorch-lightning/pull/3750, and I'd like to apply the fix here as well.

As described in detail in [this article](https://blog.ram.rachum.com/post/621791438475296768/improving-python-exception-chaining-with), exception chaining (PEP 3134) can be used to make exceptions more user-friendly, and in that case, the syntax `raise ... from ...` needs to be used.

When `raise ... from ...` is used, there will be a line saying `The above exception was the direct cause of the following exception:` between tracebacks. However, when implicitly chaining exceptions (meaning when `raise ... from ...` is not used), the message will be `During handling of the above exception, another exception occurred:` which can confuse users.

Specifically, the following should be used in order to explicitly chain exceptions:
```python
try:
    something_which_raises_OldError
except OldError as e:
    raise NewError("A more user-friendly exception message.") from e 
```
instead of:
```python
try:
    something_which_raises_OldError
except OldError:
    raise NewError("A more user-friendly exception message.")
```

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
