### PR TITLE
docs: Add empty lines before `Args:` in docstring

### DIFF
--- a/pl_bolts/callbacks/self_supervised.py
+++ b/pl_bolts/callbacks/self_supervised.py
@@ -59,6 +59,7 @@ class SSLOnlineEvaluator(pl.Callback):  # pragma: no-cover
     def get_representations(self, pl_module, x):
         """
         Override this to customize for the particular model
+
         Args:
             pl_module:
             x:

--- a/pl_bolts/datamodules/experience_source.py
+++ b/pl_bolts/datamodules/experience_source.py
@@ -83,8 +83,10 @@ class ExperienceSource(BaseExperienceSource):
     def runner(self, device: torch.device) -> Tuple[Experience]:
         """Experience Source iterator yielding Tuple of experiences for n_steps. These come from the pool
         of environments provided by the user.
+
         Args:
             device: current device to be used for executing experience steps
+
         Returns:
             Tuple of Experiences
         """
@@ -113,6 +115,7 @@ class ExperienceSource(BaseExperienceSource):
         Updates the experience history queue with the lastest experiences. In the event of an experience step is in
         the done state, the history will be incrementally appended to the queue, removing the tail of the history
         each time.
+
         Args:
             env_idx: index of the environment
             exp: the current experience
@@ -172,10 +175,12 @@ class ExperienceSource(BaseExperienceSource):
     def env_step(self, env_idx: int, env: Env, action: List[int]) -> Experience:
         """
         Carries out a step through the given environment using the given action
+
         Args:
             env_idx: index of the current environment
             env: env at index env_idx
             action: action for this environment step
+
         Returns:
             Experience tuple
         """
@@ -192,6 +197,7 @@ class ExperienceSource(BaseExperienceSource):
         """
         To be called at the end of the history tail generation during the termination state. Updates the stats
         tracked for all environments
+
         Args:
             env_idx: index of the environment used to update stats
         """
@@ -238,8 +244,10 @@ class DiscountedExperienceSource(ExperienceSource):
     def runner(self, device: torch.device) -> Experience:
         """
         Iterates through experience tuple and calculate discounted experience
+
         Args:
             device: current device to be used for executing experience steps
+
         Yields:
             Discounted Experience
         """
@@ -255,8 +263,10 @@ class DiscountedExperienceSource(ExperienceSource):
         """
         Takes in a tuple of experiences and returns the last state and tail experiences based on
         if the last state is the end of an episode
+
         Args:
             experiences: Tuple of N Experience
+
         Returns:
             last state (Array or None) and remaining Experience
         """
@@ -271,8 +281,10 @@ class DiscountedExperienceSource(ExperienceSource):
     def discount_rewards(self, experiences: Tuple[Experience]) -> float:
         """
         Calculates the discounted reward over N experiences
+
         Args:
             experiences: Tuple of Experience
+
         Returns:
             total discounted reward
         """

--- a/pl_bolts/datamodules/kitti_datamodule.py
+++ b/pl_bolts/datamodules/kitti_datamodule.py
@@ -46,7 +46,7 @@ class KittiDataModule(LightningDataModule):
 
             Trainer().fit(model, dm)
 
-        Args::
+        Args:
             data_dir: where to load the data from path, i.e. '/path/to/folder/with/data_semantics/'
             val_split: size of validation test (default 0.2)
             test_split: size of test set (default 0.1)

--- a/pl_bolts/losses/rl.py
+++ b/pl_bolts/losses/rl.py
@@ -13,11 +13,13 @@ def dqn_loss(batch: Tuple[torch.Tensor, torch.Tensor], net: nn.Module,
              target_net: nn.Module, gamma: float = 0.99) -> torch.Tensor:
     """
     Calculates the mse loss using a mini batch from the replay buffer
+
     Args:
         batch: current mini batch of replay data
         net: main training network
         target_net: target network of the main training network
         gamma: discount factor
+
     Returns:
         loss
     """
@@ -45,11 +47,13 @@ def double_dqn_loss(batch: Tuple[torch.Tensor, torch.Tensor], net: nn.Module,
     Calculates the mse loss using a mini batch from the replay buffer. This uses an improvement to the original
     DQN loss by using the double dqn. This is shown by using the actions of the train network to pick the
     value from the target network. This code is heavily commented in order to explain the process clearly
+
     Args:
         batch: current mini batch of replay data
         net: main training network
         target_net: target network of the main training network
         gamma: discount factor
+
     Returns:
         loss
     """
@@ -89,12 +93,14 @@ def per_dqn_loss(batch: Tuple[torch.Tensor, torch.Tensor], batch_weights: List, 
                  target_net: nn.Module, gamma: float = 0.99) -> Tuple[torch.Tensor, np.ndarray]:
     """
     Calculates the mse loss with the priority weights of the batch from the PER buffer
+
     Args:
         batch: current mini batch of replay data
         batch_weights: how each of these samples are weighted in terms of priority
         net: main training network
         target_net: target network of the main training network
         gamma: discount factor
+
     Returns:
         loss and batch_weights
     """

--- a/pl_bolts/models/rl/common/agents.py
+++ b/pl_bolts/models/rl/common/agents.py
@@ -20,9 +20,11 @@ class Agent(ABC):
     def __call__(self, state: torch.Tensor, device: str, *args, **kwargs) -> List[int]:
         """
         Using the given network, decide what action to carry
+
         Args:
             state: current state of the environment
             device: device used for current batch
+
         Returns:
             action
         """
@@ -51,9 +53,11 @@ class ValueAgent(Agent):
     def __call__(self, state: torch.Tensor, device: str) -> List[int]:
         """
         Takes in the current state and returns the action based on the agents policy
+
         Args:
             state: current state of the environment
             device: the device used for the current batch
+
         Returns:
             action defined by policy
         """
@@ -79,12 +83,14 @@ class ValueAgent(Agent):
 
     def get_action(self, state: torch.Tensor, device: torch.device):
         """
-            Returns the best action based on the Q values of the network
-            Args:
-                state: current state of the environment
-                device: the device used for the current batch
-            Returns:
-                action defined by Q values
+        Returns the best action based on the Q values of the network
+
+        Args:
+            state: current state of the environment
+            device: the device used for the current batch
+
+        Returns:
+            action defined by Q values
         """
         if not isinstance(state, torch.Tensor):
             state = torch.tensor(state, device=device)
@@ -96,6 +102,7 @@ class ValueAgent(Agent):
     def update_epsilon(self, step: int) -> None:
         """
         Updates the epsilon value based on the current step
+
         Args:
             step: current global step
         """
@@ -109,9 +116,11 @@ class PolicyAgent(Agent):
     def __call__(self, states: torch.Tensor, device: str) -> List[int]:
         """
         Takes in the current state and returns the action based on the agents policy
+
         Args:
             states: current state of the environment
             device: the device used for the current batch
+
         Returns:
             action defined by policy
         """

--- a/pl_bolts/models/rl/common/memory.py
+++ b/pl_bolts/models/rl/common/memory.py
@@ -30,6 +30,7 @@ class Buffer:
     def append(self, experience: Experience) -> None:
         """
         Add experience to the buffer
+
         Args:
             experience: tuple (state, action, reward, done, new_state)
         """
@@ -65,8 +66,10 @@ class ReplayBuffer(Buffer):
     def sample(self, batch_size: int) -> Tuple:
         """
         Takes a sample of the buffer
+
         Args:
             batch_size: current batch_size
+
         Returns:
             a batch of tuple np arrays of state, action, reward, done, next_state
         """
@@ -107,6 +110,7 @@ class MultiStepBuffer(ReplayBuffer):
     def append(self, exp: Experience) -> None:
         """
         Add experience to the buffer
+
         Args:
             exp: tuple (state, action, reward, done, new_state)
         """
@@ -128,6 +132,7 @@ class MultiStepBuffer(ReplayBuffer):
         Updates the experience history queue with the lastest experiences. In the event of an experience step is in
         the done state, the history will be incrementally appended to the queue, removing the tail of the history
         each time.
+
         Args:
             env_idx: index of the environment
             exp: the current experience
@@ -161,8 +166,10 @@ class MultiStepBuffer(ReplayBuffer):
         """
         Takes in a tuple of experiences and returns the last state and tail experiences based on
         if the last state is the end of an episode
+
         Args:
             experiences: Tuple of N Experience
+
         Returns:
             last state (Array or None) and remaining Experience
         """
@@ -177,8 +184,10 @@ class MultiStepBuffer(ReplayBuffer):
     def discount_rewards(self, experiences: Tuple[Experience]) -> float:
         """
         Calculates the discounted reward over N experiences
+
         Args:
             experiences: Tuple of Experience
+
         Returns:
             total discounted reward
         """
@@ -233,8 +242,10 @@ class PERBuffer(ReplayBuffer):
     def update_beta(self, step) -> float:
         """
         Update the beta value which accounts for the bias in the PER
+
         Args:
             step: current global step
+
         Returns:
             beta value for this indexed experience
         """
@@ -246,6 +257,7 @@ class PERBuffer(ReplayBuffer):
     def append(self, exp) -> None:
         """
         Adds experiences from exp_source to the PER buffer
+
         Args:
             exp: experience tuple being added to the buffer
         """
@@ -266,8 +278,10 @@ class PERBuffer(ReplayBuffer):
     def sample(self, batch_size=32) -> Tuple:
         """
         Takes a prioritized sample from the buffer
+
         Args:
             batch_size: size of sample
+
         Returns:
             sample of experiences chosen with ranked probability
         """
@@ -308,6 +322,7 @@ class PERBuffer(ReplayBuffer):
         """
         Update the priorities from the last batch, this should be called after the loss for this batch has been
         calculated.
+
         Args:
             batch_indices: index of each datum in the batch
             batch_priorities: priority of each datum in the batch

--- a/pl_bolts/models/rl/common/networks.py
+++ b/pl_bolts/models/rl/common/networks.py
@@ -41,6 +41,7 @@ class CNN(nn.Module):
     def _get_conv_out(self, shape) -> int:
         """
         Calculates the output size of the last conv layer
+
         Args:
             shape: input dimensions
         Returns:
@@ -52,6 +53,7 @@ class CNN(nn.Module):
     def forward(self, input_x) -> Tensor:
         """
         Forward pass through network
+
         Args:
             x: input to network
         Returns:
@@ -83,8 +85,10 @@ class MLP(nn.Module):
     def forward(self, input_x):
         """
         Forward pass through network
+
         Args:
             x: input to network
+
         Returns:
             output of network
         """
@@ -123,8 +127,10 @@ class DuelingMLP(nn.Module):
     def forward(self, input_x):
         """
         Forward pass through network. Calculates the Q using the value and advantage
+
         Args:
             x: input to network
+
         Returns:
             Q value
         """
@@ -136,8 +142,10 @@ class DuelingMLP(nn.Module):
         """
         Gets the advantage and value by passing out of the base network through the
         value and advantage heads
+
         Args:
             input_x: input to network
+
         Returns:
             advantage, value
         """
@@ -184,8 +192,10 @@ class DuelingCNN(nn.Module):
     def _get_conv_out(self, shape) -> int:
         """
         Calculates the output size of the last conv layer
+
         Args:
             shape: input dimensions
+
         Returns:
             size of the conv output
         """
@@ -195,8 +205,10 @@ class DuelingCNN(nn.Module):
     def forward(self, input_x):
         """
         Forward pass through network. Calculates the Q using the value and advantage
+
         Args:
             input_x: input to network
+
         Returns:
             Q value
         """
@@ -208,8 +220,10 @@ class DuelingCNN(nn.Module):
         """
         Gets the advantage and value by passing out of the base network through the
         value and advantage heads
+
         Args:
             input_x: input to network
+
         Returns:
             advantage, value
         """
@@ -248,8 +262,10 @@ class NoisyCNN(nn.Module):
     def _get_conv_out(self, shape) -> int:
         """
         Calculates the output size of the last conv layer
+
         Args:
             shape: input dimensions
+
         Returns:
             size of the conv output
         """
@@ -259,8 +275,10 @@ class NoisyCNN(nn.Module):
     def forward(self, input_x) -> Tensor:
         """
         Forward pass through network
+
         Args:
             x: input to network
+
         Returns:
             output of network
         """
@@ -312,8 +330,10 @@ class NoisyLinear(nn.Linear):
     def forward(self, input_x: Tensor) -> Tensor:
         """
         Forward pass of the layer
+
         Args:
             input_x: input tensor
+
         Returns:
             output of the layer
         """

--- a/pl_bolts/models/rl/double_dqn_model.py
+++ b/pl_bolts/models/rl/double_dqn_model.py
@@ -61,9 +61,11 @@ class DoubleDQN(DQN):
         """
         Carries out a single step through the environment to update the replay buffer.
         Then calculates loss based on the minibatch recieved
+
         Args:
             batch: current mini batch of replay data
             _: batch number, not used
+
         Returns:
             Training loss and log metrics
         """

--- a/pl_bolts/models/rl/dqn_model.py
+++ b/pl_bolts/models/rl/dqn_model.py
@@ -161,6 +161,7 @@ class DQN(pl.LightningModule):
     def run_n_episodes(self, env, n_epsiodes: int = 1, epsilon: float = 1.0) -> List[int]:
         """
         Carries out N episodes of the environment with the current agent
+
         Args:
             env: environment to use, either train environment or test environment
             n_epsiodes: number of episodes to run
@@ -208,8 +209,10 @@ class DQN(pl.LightningModule):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Passes in a state x through the network and gets the q_values of each action as an output
+
         Args:
             x: environment state
+
         Returns:
             q values
         """
@@ -266,9 +269,11 @@ class DQN(pl.LightningModule):
         """
         Carries out a single step through the environment to update the replay buffer.
         Then calculates loss based on the minibatch recieved
+
         Args:
             batch: current mini batch of replay data
             _: batch number, not used
+
         Returns:
             Training loss and log metrics
         """
@@ -346,9 +351,11 @@ class DQN(pl.LightningModule):
     def make_environment(env_name: str, seed: Optional[int] = None) -> gym.Env:
         """
         Initialise gym  environment
+
         Args:
             env_name: environment name or tag
             seed: value to seed the environment RNG for reproducibility
+
         Returns:
             gym environment
         """
@@ -365,7 +372,9 @@ class DQN(pl.LightningModule):
     ) -> argparse.ArgumentParser:
         """
         Adds arguments for DQN model
+
         Note: these params are fine tuned for Pong env
+
         Args:
             arg_parser: parent parser
         """

--- a/pl_bolts/models/rl/per_dqn_model.py
+++ b/pl_bolts/models/rl/per_dqn_model.py
@@ -121,9 +121,11 @@ class PERDQN(DQN):
         """
         Carries out a single step through the environment to update the replay buffer.
         Then calculates loss based on the minibatch recieved
+
         Args:
             batch: current mini batch of replay data
             _: batch number, not used
+
         Returns:
             Training loss and log metrics
         """

--- a/pl_bolts/models/rl/reinforce_model.py
+++ b/pl_bolts/models/rl/reinforce_model.py
@@ -119,8 +119,10 @@ class Reinforce(pl.LightningModule):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Passes in a state x through the network and gets the q_values of each action as an output
+
         Args:
             x: environment state
+
         Returns:
             q values
         """
@@ -129,8 +131,10 @@ class Reinforce(pl.LightningModule):
 
     def calc_qvals(self, rewards: List[float]) -> List[float]:
         """Calculate the discounted rewards of all rewards in list
+
         Args:
             rewards: list of rewards from latest batch
+
         Returns:
             list of discounted rewards
         """
@@ -148,8 +152,10 @@ class Reinforce(pl.LightningModule):
     def discount_rewards(self, experiences: Tuple[Experience]) -> float:
         """
         Calculates the discounted reward over N experiences
+
         Args:
             experiences: Tuple of Experience
+
         Returns:
             total discounted reward
         """
@@ -217,9 +223,11 @@ class Reinforce(pl.LightningModule):
         """
         Carries out a single step through the environment to update the replay buffer.
         Then calculates loss based on the minibatch recieved
+
         Args:
             batch: current mini batch of replay data
             _: batch number, not used
+
         Returns:
             Training loss and log metrics
         """
@@ -265,9 +273,12 @@ class Reinforce(pl.LightningModule):
     def add_model_specific_args(arg_parser) -> argparse.ArgumentParser:
         """
         Adds arguments for DQN model
+
         Note: these params are fine tuned for Pong env
+
         Args:
             arg_parser: the current argument parser to add to
+
         Returns:
             arg_parser with model specific cargs added
         """

--- a/pl_bolts/models/rl/vanilla_policy_gradient_model.py
+++ b/pl_bolts/models/rl/vanilla_policy_gradient_model.py
@@ -109,8 +109,10 @@ class VanillaPolicyGradient(pl.LightningModule):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Passes in a state x through the network and gets the q_values of each action as an output
+
         Args:
             x: environment state
+
         Returns:
             q values
         """
@@ -208,9 +210,11 @@ class VanillaPolicyGradient(pl.LightningModule):
         """
         Carries out a single step through the environment to update the replay buffer.
         Then calculates loss based on the minibatch recieved
+
         Args:
             batch: current mini batch of replay data
             _: batch number, not used
+
         Returns:
             Training loss and log metrics
         """
@@ -255,9 +259,12 @@ class VanillaPolicyGradient(pl.LightningModule):
     def add_model_specific_args(arg_parser) -> argparse.ArgumentParser:
         """
         Adds arguments for DQN model
+
         Note: these params are fine tuned for Pong env
+
         Args:
             arg_parser: the current argument parser to add to
+
         Returns:
             arg_parser with model specific cargs added
         """

--- a/pl_bolts/models/self_supervised/resnets.py
+++ b/pl_bolts/models/self_supervised/resnets.py
@@ -275,6 +275,7 @@ def _resnet(arch, block, layers, pretrained, progress, **kwargs):
 def resnet18(pretrained=False, progress=True, **kwargs):
     r"""ResNet-18 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
@@ -286,6 +287,7 @@ def resnet18(pretrained=False, progress=True, **kwargs):
 def resnet34(pretrained=False, progress=True, **kwargs):
     r"""ResNet-34 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
@@ -297,6 +299,7 @@ def resnet34(pretrained=False, progress=True, **kwargs):
 def resnet50(pretrained=False, progress=True, **kwargs):
     r"""ResNet-50 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
@@ -308,6 +311,7 @@ def resnet50(pretrained=False, progress=True, **kwargs):
 def resnet50_bn(pretrained=False, progress=True, **kwargs):
     r"""ResNet-50 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
@@ -319,6 +323,7 @@ def resnet50_bn(pretrained=False, progress=True, **kwargs):
 def resnet101(pretrained=False, progress=True, **kwargs):
     r"""ResNet-101 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
@@ -330,6 +335,7 @@ def resnet101(pretrained=False, progress=True, **kwargs):
 def resnet152(pretrained=False, progress=True, **kwargs):
     r"""ResNet-152 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
@@ -341,6 +347,7 @@ def resnet152(pretrained=False, progress=True, **kwargs):
 def resnext50_32x4d(pretrained=False, progress=True, **kwargs):
     r"""ResNeXt-50 32x4d model from
     `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
@@ -354,6 +361,7 @@ def resnext50_32x4d(pretrained=False, progress=True, **kwargs):
 def resnext101_32x8d(pretrained=False, progress=True, **kwargs):
     r"""ResNeXt-101 32x8d model from
     `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
@@ -371,6 +379,7 @@ def wide_resnet50_2(pretrained=False, progress=True, **kwargs):
     which is twice larger in every block. The number of channels in outer 1x1
     convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
     channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
@@ -387,6 +396,7 @@ def wide_resnet101_2(pretrained=False, progress=True, **kwargs):
     which is twice larger in every block. The number of channels in outer 1x1
     convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
     channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
There should be an empty line above `Args:` to properly render docs. This PR adds an empty line right above each `Args:` in docstring for proper docs output.

Run the following command to get a list of lines where an empty line should be inserted:
`grep -B1 "Args:" -rn .|grep -v "\"\"\""|grep -v "Binary file"|grep -v "\-\-"|grep -v "Args:"|grep -v "\-$"`

Output:
```shell
./pl_bolts/datamodules/experience_source.py-85-        of environments provided by the user.
./pl_bolts/datamodules/experience_source.py-115-        each time.
./pl_bolts/datamodules/experience_source.py-174-        Carries out a step through the given environment using the given action
./pl_bolts/datamodules/experience_source.py-194-        tracked for all environments
./pl_bolts/datamodules/experience_source.py-240-        Iterates through experience tuple and calculate discounted experience
./pl_bolts/datamodules/experience_source.py-257-        if the last state is the end of an episode
./pl_bolts/datamodules/experience_source.py-273-        Calculates the discounted reward over N experiences
./pl_bolts/models/self_supervised/resnets.py-277-    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
./pl_bolts/models/self_supervised/resnets.py-288-    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
./pl_bolts/models/self_supervised/resnets.py-299-    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
./pl_bolts/models/self_supervised/resnets.py-310-    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
./pl_bolts/models/self_supervised/resnets.py-321-    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
./pl_bolts/models/self_supervised/resnets.py-332-    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
./pl_bolts/models/self_supervised/resnets.py-343-    `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
./pl_bolts/models/self_supervised/resnets.py-356-    `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
./pl_bolts/models/self_supervised/resnets.py-373-    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
./pl_bolts/models/self_supervised/resnets.py-389-    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
./pl_bolts/models/rl/dqn_model.py-163-        Carries out N episodes of the environment with the current agent
./pl_bolts/models/rl/dqn_model.py-210-        Passes in a state x through the network and gets the q_values of each action as an output
./pl_bolts/models/rl/dqn_model.py-268-        Then calculates loss based on the minibatch recieved
./pl_bolts/models/rl/dqn_model.py-348-        Initialise gym  environment
./pl_bolts/models/rl/dqn_model.py-368-        Note: these params are fine tuned for Pong env
./pl_bolts/models/rl/reinforce_model.py-121-        Passes in a state x through the network and gets the q_values of each action as an output
./pl_bolts/models/rl/reinforce_model.py-150-        Calculates the discounted reward over N experiences
./pl_bolts/models/rl/reinforce_model.py-219-        Then calculates loss based on the minibatch recieved
./pl_bolts/models/rl/reinforce_model.py-268-        Note: these params are fine tuned for Pong env
./pl_bolts/models/rl/double_dqn_model.py-63-        Then calculates loss based on the minibatch recieved
./pl_bolts/models/rl/per_dqn_model.py-123-        Then calculates loss based on the minibatch recieved
./pl_bolts/models/rl/vanilla_policy_gradient_model.py-111-        Passes in a state x through the network and gets the q_values of each action as an output
./pl_bolts/models/rl/vanilla_policy_gradient_model.py-210-        Then calculates loss based on the minibatch recieved
./pl_bolts/models/rl/vanilla_policy_gradient_model.py-258-        Note: these params are fine tuned for Pong env
./pl_bolts/models/rl/common/agents.py-22-        Using the given network, decide what action to carry
./pl_bolts/models/rl/common/agents.py-53-        Takes in the current state and returns the action based on the agents policy
./pl_bolts/models/rl/common/agents.py-82-            Returns the best action based on the Q values of the network
./pl_bolts/models/rl/common/agents.py-98-        Updates the epsilon value based on the current step
./pl_bolts/models/rl/common/agents.py-111-        Takes in the current state and returns the action based on the agents policy
./pl_bolts/models/rl/common/networks.py-43-        Calculates the output size of the last conv layer
./pl_bolts/models/rl/common/networks.py-54-        Forward pass through network
./pl_bolts/models/rl/common/networks.py-85-        Forward pass through network
./pl_bolts/models/rl/common/networks.py-125-        Forward pass through network. Calculates the Q using the value and advantage
./pl_bolts/models/rl/common/networks.py-138-        value and advantage heads
./pl_bolts/models/rl/common/networks.py-186-        Calculates the output size of the last conv layer
./pl_bolts/models/rl/common/networks.py-197-        Forward pass through network. Calculates the Q using the value and advantage
./pl_bolts/models/rl/common/networks.py-210-        value and advantage heads
./pl_bolts/models/rl/common/networks.py-250-        Calculates the output size of the last conv layer
./pl_bolts/models/rl/common/networks.py-261-        Forward pass through network
./pl_bolts/models/rl/common/networks.py-314-        Forward pass of the layer
./pl_bolts/models/rl/common/memory.py-32-        Add experience to the buffer
./pl_bolts/models/rl/common/memory.py-67-        Takes a sample of the buffer
./pl_bolts/models/rl/common/memory.py-109-        Add experience to the buffer
./pl_bolts/models/rl/common/memory.py-130-        each time.
./pl_bolts/models/rl/common/memory.py-163-        if the last state is the end of an episode
./pl_bolts/models/rl/common/memory.py-179-        Calculates the discounted reward over N experiences
./pl_bolts/models/rl/common/memory.py-235-        Update the beta value which accounts for the bias in the PER
./pl_bolts/models/rl/common/memory.py-248-        Adds experiences from exp_source to the PER buffer
./pl_bolts/models/rl/common/memory.py-268-        Takes a prioritized sample from the buffer
./pl_bolts/models/rl/common/memory.py-310-        calculated.
./pl_bolts/losses/rl.py-15-    Calculates the mse loss using a mini batch from the replay buffer
./pl_bolts/losses/rl.py-47-    value from the target network. This code is heavily commented in order to explain the process clearly
./pl_bolts/losses/rl.py-91-    Calculates the mse loss with the priority weights of the batch from the PER buffer
./pl_bolts/callbacks/self_supervised.py-61-        Override this to customize for the particular mode
```
## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
