### PR TITLE
update swav to override optimizer_step with optimizer.step(closure=op…

### DIFF
--- a/pl_bolts/models/self_supervised/swav/swav_module.py
+++ b/pl_bolts/models/self_supervised/swav/swav_module.py
@@ -322,14 +322,14 @@ class SwAV(pl.LightningModule):
 
     def optimizer_step(
         self,
-        epoch,
-        batch_idx,
-        optimizer,
-        optimizer_idx,
-        optimizer_closure,
-        on_tpu,
-        using_native_amp,
-        using_lbfgs,
+        epoch: int,
+        batch_idx: int,
+        optimizer: Optimizer,
+        optimizer_idx: int,
+        optimizer_closure: Optional[Callable] = None,
+        on_tpu: bool = False,
+        using_native_amp: bool = False,
+        using_lbfgs: bool = False,
     ) -> None:
         # warm-up + decay schedule placed here since LARSWrapper is not optimizer class
         # adjust LR of optim contained within LARSWrapper

--- a/pl_bolts/models/self_supervised/swav/swav_module.py
+++ b/pl_bolts/models/self_supervised/swav/swav_module.py
@@ -349,13 +349,9 @@ class SwAV(pl.LightningModule):
         if on_tpu:
             xm.optimizer_step(optimizer, optimizer_args={'closure': optimizer_closure})
         elif self.trainer.amp_backend == AMPType.NATIVE:
-            # native amp does not yet support closures.
-            # TODO: pass the closure to the step ASAP
             optimizer_closure()
             self.trainer.scaler.step(optimizer)
         elif self.trainer.amp_backend == AMPType.APEX:
-            # apex amp does not yet support closures.
-            # TODO: pass the closure to the step ASAP
             optimizer_closure()
             optimizer.step()
         else:

--- a/pl_bolts/models/self_supervised/swav/swav_module.py
+++ b/pl_bolts/models/self_supervised/swav/swav_module.py
@@ -22,11 +22,6 @@ from pl_bolts.optimizers.lars_scheduling import LARSWrapper
 
 from pytorch_lightning.utilities.xla_device_utils import XLADeviceUtils
 
-TPU_AVAILABLE = XLADeviceUtils.tpu_device_exists()
-
-if TPU_AVAILABLE:
-    import torch_xla.core.xla_model as xm
-
 
 class SwAV(pl.LightningModule):
     def __init__(
@@ -352,17 +347,16 @@ class SwAV(pl.LightningModule):
         # log LR (LearningRateLogger callback doesn't work with LARSWrapper)
         self.log('learning_rate', self.lr_schedule[self.trainer.global_step], on_step=True, on_epoch=False)
 
-        # from lightning implementation
-        if on_tpu:
-            xm.optimizer_step(optimizer, optimizer_args={'closure': optimizer_closure})
-        elif self.trainer.amp_backend == AMPType.NATIVE:
-            optimizer_closure()
-            self.trainer.scaler.step(optimizer)
-        elif self.trainer.amp_backend == AMPType.APEX:
-            optimizer_closure()
-            optimizer.step()
-        else:
-            optimizer.step(closure=optimizer_closure)
+        super().optimizer_step(
+            epoch=epoch,
+            batch_idx=batch_idx,
+            optimizer=optimizer,
+            optimizer_idx=optimizer_idx,
+            optimizer_closure=optimizer_closure,
+            on_tpu=on_tpu,
+            using_native_amp=using_native_amp,
+            using_lbfgs=using_lbfgs,
+        )
 
     def sinkhorn(self, Q, nmb_iters):
         with torch.no_grad():

--- a/pl_bolts/models/self_supervised/swav/swav_module.py
+++ b/pl_bolts/models/self_supervised/swav/swav_module.py
@@ -11,7 +11,9 @@ import pytorch_lightning as pl
 import torch
 import torch.distributed as dist
 from torch import nn
+from torch.optim.optimizer import Optimizer
 
+from typing import Callable, Optional
 from pytorch_lightning.utilities import AMPType
 
 from pl_bolts.models.self_supervised.swav.swav_resnet import resnet50, resnet18

--- a/pl_bolts/models/self_supervised/swav/swav_module.py
+++ b/pl_bolts/models/self_supervised/swav/swav_module.py
@@ -20,8 +20,6 @@ from pl_bolts.models.self_supervised.swav.swav_resnet import resnet50, resnet18
 from pl_bolts.transforms.dataset_normalizations import stl10_normalization, cifar10_normalization
 from pl_bolts.optimizers.lars_scheduling import LARSWrapper
 
-from pytorch_lightning.utilities.xla_device_utils import XLADeviceUtils
-
 
 class SwAV(pl.LightningModule):
     def __init__(

--- a/pl_bolts/models/self_supervised/swav/swav_module.py
+++ b/pl_bolts/models/self_supervised/swav/swav_module.py
@@ -20,6 +20,13 @@ from pl_bolts.models.self_supervised.swav.swav_resnet import resnet50, resnet18
 from pl_bolts.transforms.dataset_normalizations import stl10_normalization, cifar10_normalization
 from pl_bolts.optimizers.lars_scheduling import LARSWrapper
 
+from pytorch_lightning.utilities.xla_device_utils import XLADeviceUtils
+
+TPU_AVAILABLE = XLADeviceUtils.tpu_device_exists()
+
+if TPU_AVAILABLE:
+    import torch_xla.core.xla_model as xm
+
 
 class SwAV(pl.LightningModule):
     def __init__(

--- a/tests/models/self_supervised/test_models.py
+++ b/tests/models/self_supervised/test_models.py
@@ -131,5 +131,7 @@ def test_swav(tmpdir):
         gpus=0, fast_dev_run=True, max_epochs=1, default_root_dir=tmpdir, max_steps=3
     )
 
-    results = trainer.fit(model, datamodule)
-    assert results == 1
+    trainer.fit(model, datamodule)
+    loss = trainer.progress_bar_dict['loss']
+
+    assert float(loss) > 0


### PR DESCRIPTION

## What does this PR do?

fixes swav with optimizer.step(closure=optimizer_closure). Otherwise training_step was being skipped.

blocked by/tests failing due to: https://github.com/PyTorchLightning/pytorch-lightning/pull/4455
needs lightning to update to this PR.