### PR TITLE
Use kl_coeff in loss function calculation

### DIFF
--- a/pl_bolts/models/autoencoders/basic_ae/basic_ae_module.py
+++ b/pl_bolts/models/autoencoders/basic_ae/basic_ae_module.py
@@ -36,7 +36,6 @@ class AE(pl.LightningModule):
         first_conv: bool = False,
         maxpool1: bool = False,
         enc_out_dim: int = 512,
-        kl_coeff: float = 0.1,
         latent_dim: int = 256,
         lr: float = 1e-4,
         **kwargs

--- a/pl_bolts/models/autoencoders/basic_vae/basic_vae_module.py
+++ b/pl_bolts/models/autoencoders/basic_vae/basic_vae_module.py
@@ -127,6 +127,7 @@ class VAE(pl.LightningModule):
 
         kl = log_qz - log_pz
         kl = kl.mean()
+        kl *= self.kl_coeff
 
         loss = kl + recon_loss
 


### PR DESCRIPTION
## What does this PR do?

The VAE model contained here takes an optional `kl_coeff` parameter that's supposed to be a scaling factor for the KL term of the variational loss. This might be useful to avoid the "posterior collapse phenomenon". This pull request makes sure that it's used in the loss function.

Fixes #328.

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes? _not needed_
- [ ] Did you write any new necessary tests? _not needed_
- [ ] Did you verify new and existing tests pass locally with your changes? _no changes in tests_
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)? _it's a bug fix, no new feature_

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Absolutely! =)
