### PR TITLE
bugfix: batch_size for MNISTDataModule

### DIFF
--- a/pl_bolts/datamodules/mnist_datamodule.py
+++ b/pl_bolts/datamodules/mnist_datamodule.py
@@ -93,14 +93,14 @@ class MNISTDataModule(LightningDataModule):
         MNIST(self.data_dir, train=True, download=True, transform=transform_lib.ToTensor())
         MNIST(self.data_dir, train=False, download=True, transform=transform_lib.ToTensor())
 
-    def train_dataloader(self, transforms=None):
+    def train_dataloader(self):
         """
         MNIST train set removes a subset to use for validation
 
         Args:
             transforms: custom transforms
         """
-        transforms = transforms or self.train_transforms or self._default_transforms()
+        transforms = self.default_transforms() if self.train_transforms is None else self.train_transforms
 
         dataset = MNIST(self.data_dir, train=True, download=False, transform=transforms)
         train_length = len(dataset)
@@ -117,14 +117,14 @@ class MNISTDataModule(LightningDataModule):
         )
         return loader
 
-    def val_dataloader(self, transforms=None):
+    def val_dataloader(self):
         """
         MNIST val set uses a subset of the training set for validation
 
         Args:
             transforms: custom transforms
         """
-        transforms = transforms or self.val_transforms or self._default_transforms()
+        transforms = self.default_transforms() if self.val_transforms is None else self.val_transforms
         dataset = MNIST(self.data_dir, train=True, download=False, transform=transforms)
         train_length = len(dataset)
         _, dataset_val = random_split(
@@ -140,14 +140,14 @@ class MNISTDataModule(LightningDataModule):
         )
         return loader
 
-    def test_dataloader(self, transforms=None):
+    def test_dataloader(self):
         """
         MNIST test set uses the test split
 
         Args:
             transforms: custom transforms
         """
-        transforms = transforms or self.val_transforms or self._default_transforms()
+        transforms = self.default_transforms() if self.test_transforms is None else self.test_transforms
 
         dataset = MNIST(self.data_dir, train=False, download=False, transform=transforms)
         loader = DataLoader(
@@ -156,7 +156,7 @@ class MNISTDataModule(LightningDataModule):
         )
         return loader
 
-    def _default_transforms(self):
+    def default_transforms(self):
         if self.normalize:
             mnist_transforms = transform_lib.Compose(
                 [transform_lib.ToTensor(), transform_lib.Normalize(mean=(0.5,), std=(0.5,))]

--- a/pl_bolts/datamodules/mnist_datamodule.py
+++ b/pl_bolts/datamodules/mnist_datamodule.py
@@ -76,6 +76,7 @@ class MNISTDataModule(LightningDataModule):
         self.num_workers = num_workers
         self.normalize = normalize
         self.seed = seed
+        self.batch_size = batch_size
 
     @property
     def num_classes(self):
@@ -92,12 +93,11 @@ class MNISTDataModule(LightningDataModule):
         MNIST(self.data_dir, train=True, download=True, transform=transform_lib.ToTensor())
         MNIST(self.data_dir, train=False, download=True, transform=transform_lib.ToTensor())
 
-    def train_dataloader(self, batch_size=32, transforms=None):
+    def train_dataloader(self, transforms=None):
         """
         MNIST train set removes a subset to use for validation
 
         Args:
-            batch_size: size of batch
             transforms: custom transforms
         """
         transforms = transforms or self.train_transforms or self._default_transforms()
@@ -109,7 +109,7 @@ class MNISTDataModule(LightningDataModule):
         )
         loader = DataLoader(
             dataset_train,
-            batch_size=batch_size,
+            batch_size=self.batch_size,
             shuffle=True,
             num_workers=self.num_workers,
             drop_last=True,
@@ -117,12 +117,11 @@ class MNISTDataModule(LightningDataModule):
         )
         return loader
 
-    def val_dataloader(self, batch_size=32, transforms=None):
+    def val_dataloader(self, transforms=None):
         """
         MNIST val set uses a subset of the training set for validation
 
         Args:
-            batch_size: size of batch
             transforms: custom transforms
         """
         transforms = transforms or self.val_transforms or self._default_transforms()
@@ -133,7 +132,7 @@ class MNISTDataModule(LightningDataModule):
         )
         loader = DataLoader(
             dataset_val,
-            batch_size=batch_size,
+            batch_size=self.batch_size,
             shuffle=False,
             num_workers=self.num_workers,
             drop_last=True,
@@ -141,19 +140,19 @@ class MNISTDataModule(LightningDataModule):
         )
         return loader
 
-    def test_dataloader(self, batch_size=32, transforms=None):
+    def test_dataloader(self, transforms=None):
         """
         MNIST test set uses the test split
 
         Args:
-            batch_size: size of batch
             transforms: custom transforms
         """
         transforms = transforms or self.val_transforms or self._default_transforms()
 
         dataset = MNIST(self.data_dir, train=False, download=False, transform=transforms)
         loader = DataLoader(
-            dataset, batch_size=batch_size, shuffle=False, num_workers=self.num_workers, drop_last=True, pin_memory=True
+            dataset, batch_size=self.batch_size, shuffle=False, num_workers=self.num_workers, drop_last=True,
+            pin_memory=True
         )
         return loader
 


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Properly fixes #171 fixes #334 
`batch_size` wasn't getting saved at the constructor and thus defaulting to 32. Now it behaves like other datamodules (i.e. `CIFAR10DataModule`).

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
