### PR TITLE
Ensure sync across val/test step when using DDP

### DIFF
--- a/pl_bolts/models/self_supervised/ssl_finetuner.py
+++ b/pl_bolts/models/self_supervised/ssl_finetuner.py
@@ -106,7 +106,7 @@ class SSLFineTuner(pl.LightningModule):
         acc = self.val_acc(logits, y)
 
         self.log('val_loss', loss, prog_bar=True, sync_dist=True)
-        self.log('val_acc', self.val_acc, sync_dist=True)
+        self.log('val_acc', self.val_acc)
 
         return loss
 
@@ -115,7 +115,7 @@ class SSLFineTuner(pl.LightningModule):
         acc = self.test_acc(logits, y)
 
         self.log('test_loss', loss, sync_dist=True)
-        self.log('test_acc', self.test_acc, sync_dist=True)
+        self.log('test_acc', self.test_acc)
 
         return loss
 

--- a/pl_bolts/models/self_supervised/ssl_finetuner.py
+++ b/pl_bolts/models/self_supervised/ssl_finetuner.py
@@ -105,8 +105,8 @@ class SSLFineTuner(pl.LightningModule):
         loss, logits, y = self.shared_step(batch)
         acc = self.val_acc(logits, y)
 
-        self.log('val_loss', loss, prog_bar=True)
-        self.log('val_acc', self.val_acc)
+        self.log('val_loss', loss, prog_bar=True, sync_dist=True)
+        self.log('val_acc', self.val_acc, sync_dist=True)
 
         return loss
 
@@ -114,8 +114,8 @@ class SSLFineTuner(pl.LightningModule):
         loss, logits, y = self.shared_step(batch)
         acc = self.test_acc(logits, y)
 
-        self.log('test_loss', loss)
-        self.log('test_acc', self.test_acc)
+        self.log('test_loss', loss, sync_dist=True)
+        self.log('test_acc', self.test_acc, sync_dist=True)
 
         return loss
 


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/4693

Lightning behaviour assumes that if no `monitor` key is passed to the checkpoint function, to assume `val_loss` or `checkpoint_on` as the key to save top k models. This means we have to ensure that this is synced correctly on all processes so that they are in sync when tracking the best models.

## PR review
 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
