### PR TITLE
fix last batch index error reinforce

### DIFF
--- a/pl_bolts/models/rl/reinforce_model.py
+++ b/pl_bolts/models/rl/reinforce_model.py
@@ -215,7 +215,7 @@ class Reinforce(pl.LightningModule):
 
         # policy loss
         log_prob = log_softmax(logits, dim=1)
-        log_prob_actions = scaled_rewards * log_prob[range(self.batch_size), actions]
+        log_prob_actions = scaled_rewards * log_prob[range(len(log_prob)), actions]
         loss = -log_prob_actions.mean()
 
         return loss


### PR DESCRIPTION
## What does this PR do?

This PR replaces getting batch size from self when calculating loss with using the length of the tensor, fixing an IndexError in [Reinforce](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/pl_bolts/models/rl/reinforce_model.py)

The error was an IndexError (size mismatch)  occurring on the last batch of the epoch because tensor size wasn't equal to `self.batch_size`. The number of samples in the dataset may not be divisible by `self.batch_size`, because trajectory collection here is done based on the number of episodes rather than the number of samples. Rather than fixing the error using `drop_last=True` in dataloader, this approach uses all trajectory data 

Fixes #381 

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes? _No changes_
- [ ] Did you write any new necessary tests?


## Did you have fun?
Make sure you had fun coding 🙃
