### PR TITLE
fix loss test case for batch size variation

### DIFF
--- a/tests/models/rl/unit/test_reinforce.py
+++ b/tests/models/rl/unit/test_reinforce.py
@@ -37,9 +37,9 @@ class TestReinforce(TestCase):
     def test_loss(self):
         """Test the reinforce loss function"""
 
-        batch_states = torch.rand(32, 4)
-        batch_actions = torch.rand(32).long()
-        batch_qvals = torch.rand(32)
+        batch_states = torch.rand(16, 4)
+        batch_actions = torch.rand(16).long()
+        batch_qvals = torch.rand(16)
 
         loss = self.model.loss(batch_states, batch_actions, batch_qvals)
 


### PR DESCRIPTION
## What does this PR do?
Fixes a test case ([test_loss](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/ecbb82a057c9be6caa06b0b8885743db8a1a752a/tests/models/rl/unit/test_reinforce.py#L37)) for [Reinforce ](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/pl_bolts/models/rl/reinforce_model.py)to account for the index error that was occurring in the loss function (before #389 fix). I modified the size of the tensor in test_loss from 32 (which is equal to the user-defined batch_size) to 16. This PR ensures that loss function is compatible with variation in batch sizes that occur during training

Fixes # (issue)
Test case for PR #389 

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you write any new necessary tests?
- [x] Did you verify new and existing tests pass locally with your changes?


## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
