### PR TITLE
tests: Use cached datasets in LitMNIST and the doctests

### DIFF
--- a/pl_bolts/datasets/cifar10_dataset.py
+++ b/pl_bolts/datasets/cifar10_dataset.py
@@ -41,7 +41,7 @@ class CIFAR10(LightDataset):
         >>> from torchvision import transforms
         >>> from pl_bolts.transforms.dataset_normalizations import cifar10_normalization
         >>> cf10_transforms = transforms.Compose([transforms.ToTensor(), cifar10_normalization()])
-        >>> dataset = CIFAR10(download=True, transform=cf10_transforms)
+        >>> dataset = CIFAR10(download=True, transform=cf10_transforms, data_dir="datasets")
         >>> len(dataset)
         50000
         >>> torch.bincount(dataset.targets)
@@ -167,7 +167,7 @@ class TrialCIFAR10(CIFAR10):
     without the torchvision dependency.
     Examples:
 
-        >>> dataset = TrialCIFAR10(download=True, num_samples=150, labels=(1, 5, 8))
+        >>> dataset = TrialCIFAR10(download=True, num_samples=150, labels=(1, 5, 8), data_dir="datasets")
         >>> len(dataset)
         450
         >>> sorted(set([d.item() for d in dataset.targets]))

--- a/tests/callbacks/test_data_monitor.py
+++ b/tests/callbacks/test_data_monitor.py
@@ -16,11 +16,11 @@ from pl_bolts.models import LitMNIST
 )
 @mock.patch("pl_bolts.callbacks.data_monitor.DataMonitorBase.log_histogram")
 def test_base_log_interval_override(
-    log_histogram, tmpdir, log_every_n_steps, max_steps, expected_calls
+    log_histogram, tmpdir, log_every_n_steps, max_steps, expected_calls, datadir
 ):
     """ Test logging interval set by log_every_n_steps argument. """
     monitor = TrainingDataMonitor(log_every_n_steps=log_every_n_steps)
-    model = LitMNIST(num_workers=0)
+    model = LitMNIST(data_dir=datadir, num_workers=0)
     trainer = Trainer(
         default_root_dir=tmpdir,
         log_every_n_steps=1,
@@ -43,11 +43,11 @@ def test_base_log_interval_override(
 )
 @mock.patch("pl_bolts.callbacks.data_monitor.DataMonitorBase.log_histogram")
 def test_base_log_interval_fallback(
-    log_histogram, tmpdir, log_every_n_steps, max_steps, expected_calls
+    log_histogram, tmpdir, log_every_n_steps, max_steps, expected_calls, datadir
 ):
     """ Test that if log_every_n_steps not set in the callback, fallback to what is defined in the Trainer. """
     monitor = TrainingDataMonitor()
-    model = LitMNIST(num_workers=0)
+    model = LitMNIST(data_dir=datadir, num_workers=0)
     trainer = Trainer(
         default_root_dir=tmpdir,
         log_every_n_steps=log_every_n_steps,
@@ -81,10 +81,10 @@ def test_base_unsupported_logger_warning(tmpdir):
 
 
 @mock.patch("pl_bolts.callbacks.data_monitor.TrainingDataMonitor.log_histogram")
-def test_training_data_monitor(log_histogram, tmpdir):
+def test_training_data_monitor(log_histogram, tmpdir, datadir):
     """ Test that the TrainingDataMonitor logs histograms of data points going into training_step. """
     monitor = TrainingDataMonitor()
-    model = LitMNIST()
+    model = LitMNIST(data_dir=datadir)
     trainer = Trainer(
         default_root_dir=tmpdir, log_every_n_steps=1, callbacks=[monitor],
     )


### PR DESCRIPTION
## What does this PR do?
The current tests for LitMNIST do not use cached datasets, and the doctests, neither. This PR makes sure that those tests use cached datasets in `./datasets/`

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues, there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
