### PR TITLE
Remove unused arguments in FasterRCNN

### DIFF
--- a/pl_bolts/models/detection/faster_rcnn.py
+++ b/pl_bolts/models/detection/faster_rcnn.py
@@ -122,9 +122,6 @@ class FasterRCNN(pl.LightningModule):
         parser.add_argument("--pretrained_backbone", type=bool, default=True)
         parser.add_argument("--trainable_backbone_layers", type=int, default=3)
         parser.add_argument("--replace_head", type=bool, default=True)
-
-        parser.add_argument("--data_dir", type=str, default=".")
-        parser.add_argument("--batch_size", type=int, default=1)
         return parser
 
 


### PR DESCRIPTION
## What does this PR do?
As @senarvi pointed out in #417 that
> the --batch_size argument has no effect in the the FasterRCNN model.

, this PR removes the arguments from the model since it can be specified in datamodule.

Related: #207 

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
