### PR TITLE
clear replay buffer after trajectory collection 

### DIFF
--- a/pl_bolts/models/rl/reinforce_model.py
+++ b/pl_bolts/models/rl/reinforce_model.py
@@ -206,6 +206,10 @@ class Reinforce(pl.LightningModule):
 
                 self.batch_episodes = 0
 
+                self.batch_states.clear()
+                self.batch_actions.clear()
+                self.batch_qvals.clear()
+
             # Simulates epochs
             if self.total_steps % self.batches_per_epoch == 0:
                 break


### PR DESCRIPTION
## What does this PR do?
clears replay buffer (states, actions, qvals lists) after each training batch. 

the `num_batch_episodes` parameter in reinforce controls the number of episodes to rollout in each training batch. However, since the buffer is never cleared, each training batch has all previous episodes instead of just `num_batch_episodes `. in consequence even the training time is abnormally large as all trajectories from start are accumulating in the training dataset, instead of just having `num_batch_episodes ` trajectories under the current policy. 

The [script ](https://github.com/PacktPublishing/Deep-Reinforcement-Learning-Hands-On-Second-Edition/blob/master/Chapter11/02_cartpole_reinforce.py) cited in [reinforce_model.py](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/pl_bolts/models/rl/reinforce_model.py) also does clear the replay buffer as in the fix.


Fixes #399 

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
