### PR TITLE
ci: Change the filename of make-docs artifact

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Upload built docs
         uses: actions/upload-artifact@v2
         with:
-          name: docs-results-${{ GITHUB_SHA }}
+          name: docs-results-${GITHUB_SHA}
           path: docs/build/html/
         # Use always() to always run this step to publish test results when there are test failures
         if: success()

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Upload built docs
         uses: actions/upload-artifact@v2
         with:
-          name: docs-results-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.requires }}
+          name: docs-results-${{ GITHUB_SHA }}
           path: docs/build/html/
         # Use always() to always run this step to publish test results when there are test failures
         if: success()

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Upload built docs
         uses: actions/upload-artifact@v2
         with:
-          name: docs-results-${GITHUB_SHA}
+          name: docs-results-${{ github.sha }}
           path: docs/build/html/
         # Use always() to always run this step to publish test results when there are test failures
         if: success()


### PR DESCRIPTION
## What does this PR do?
Not a strong opinion, but I'd like to suggest a tiny improvement in the filename of an artifact generated from CI `make-docs`.

Before the change:
```
docs-results-Linux--.zip
```
After the change:
```
 docs-results-d83369d51b256afb98ef5f6a4559127225db67ac.zip
```

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
