### PR TITLE
Variable name is not align with meaning

### DIFF
--- a/pl_bolts/models/self_supervised/cpc/cpc_module.py
+++ b/pl_bolts/models/self_supervised/cpc/cpc_module.py
@@ -111,10 +111,10 @@ class CPCV2(pl.LightningModule):
     def __recover_z_shape(self, Z, b):
         # recover shape
         Z = Z.squeeze(-1)
-        nb_patch = int(math.sqrt(Z.size(0) // b))
+        nb_patches = int(math.sqrt(Z.size(0) // b))
         Z = Z.view(b, -1, Z.size(1))
         Z = Z.permute(0, 2, 1).contiguous()
-        Z = Z.view(b, -1, nb_patch, nb_patch)
+        Z = Z.view(b, -1, nb_patches, nb_patches)
 
         return Z
 

--- a/pl_bolts/models/self_supervised/cpc/cpc_module.py
+++ b/pl_bolts/models/self_supervised/cpc/cpc_module.py
@@ -111,10 +111,10 @@ class CPCV2(pl.LightningModule):
     def __recover_z_shape(self, Z, b):
         # recover shape
         Z = Z.squeeze(-1)
-        nb_feats = int(math.sqrt(Z.size(0) // b))
+        nb_patch = int(math.sqrt(Z.size(0) // b))
         Z = Z.view(b, -1, Z.size(1))
         Z = Z.permute(0, 2, 1).contiguous()
-        Z = Z.view(b, -1, nb_feats, nb_feats)
+        Z = Z.view(b, -1, nb_patch, nb_patch)
 
         return Z
 


### PR DESCRIPTION
CPC has function which transform the batch to a HxH patches z-latents.
I think this is miss-spelling as the name of the variable implies "features" count, instead of "patches" count.