### PR TITLE
Add missing `,` to `pl_bolts/models/self_supervised/__init__.py`

### DIFF
--- a/pl_bolts/models/self_supervised/__init__.py
+++ b/pl_bolts/models/self_supervised/__init__.py
@@ -27,7 +27,6 @@ from pl_bolts.models.self_supervised.simclr.simclr_module import SimCLR  # noqa:
 from pl_bolts.models.self_supervised.ssl_finetuner import SSLFineTuner  # noqa: F401
 from pl_bolts.models.self_supervised.swav.swav_module import SwAV  # noqa: F401
 
-
 __all__ = [
     "AMDIM",
     "BYOL",

--- a/pl_bolts/models/self_supervised/__init__.py
+++ b/pl_bolts/models/self_supervised/__init__.py
@@ -32,7 +32,7 @@ __all__ = [
     "AMDIM",
     "BYOL",
     "CPCV2",
-    "SSLEvaluator"
+    "SSLEvaluator",
     "MocoV2",
     "SimCLR",
     "SSLFineTuner",

--- a/pl_bolts/models/self_supervised/cpc/__init__.py
+++ b/pl_bolts/models/self_supervised/cpc/__init__.py
@@ -9,7 +9,6 @@ from pl_bolts.models.self_supervised.cpc.transforms import (  # noqa: F401
     CPCTrainTransformsSTL10,
 )
 
-
 __all__ = [
     "CPCV2",
     "cpc_resnet50",

--- a/pl_bolts/models/self_supervised/simclr/transforms.py
+++ b/pl_bolts/models/self_supervised/simclr/transforms.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pl_bolts.utils import _TORCHVISION_AVAILABLE, _OPENCV_AVAILABLE
+from pl_bolts.utils import _OPENCV_AVAILABLE, _TORCHVISION_AVAILABLE
 from pl_bolts.utils.warnings import warn_missing_pkg
 
 if _TORCHVISION_AVAILABLE:

--- a/pl_bolts/models/self_supervised/swav/__init__.py
+++ b/pl_bolts/models/self_supervised/swav/__init__.py
@@ -6,7 +6,6 @@ from pl_bolts.models.self_supervised.swav.transforms import (  # noqa: F401
     SwAVTrainDataTransform,
 )
 
-
 __all__ = [
     "SwAV",
     "resnet18",


### PR DESCRIPTION
## What does this PR do?
The tests are failing due to missing `,` in `__init__.py`. Sorry I wasn't careful enough to notice in #481...
cc: @Borda 

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
