### PR TITLE
check in unet constructor that num_layers > 0

### DIFF
--- a/pl_bolts/models/vision/unet.py
+++ b/pl_bolts/models/vision/unet.py
@@ -30,6 +30,10 @@ class UNet(nn.Module):
             features_start: int = 64,
             bilinear: bool = False
     ):
+
+        if (num_layers < 1):
+            raise ValueError(f'num_layers = {num_layers}, expected: num_layers > 0')
+
         super().__init__()
         self.num_layers = num_layers
 

--- a/pl_bolts/models/vision/unet.py
+++ b/pl_bolts/models/vision/unet.py
@@ -31,7 +31,7 @@ class UNet(nn.Module):
             bilinear: bool = False
     ):
 
-        if (num_layers < 1):
+        if num_layers < 1:
             raise ValueError(f'num_layers = {num_layers}, expected: num_layers > 0')
 
         super().__init__()


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

UNet constructor now checks that num_layers > 0 and raises an exception if not.
It fixes an issue where use of UNet with num_layers = 0 fails in the forward method
with IndexError: list index out of range which is an unhelpful error message.

Fixes #486

## Before submitting
- [X] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [X] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [X] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
