### PR TITLE
Add installation guide to docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ PyTorch-Lightning-Bolts documentation
    :name: start
    :caption: Start here
 
+   installation
    introduction_guide
    models
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,0 +1,21 @@
+Installation
+============
+
+You can install using `pip <https://pypi.org/project/pytorch-lightning/>`_
+
+.. code-block:: bash
+
+   pip install pytorch-lightning-bolts
+
+Install bleeding-edge (no guarantees)
+
+.. code-block:: bash
+
+   pip install git+https://github.com/PytorchLightning/pytorch-lightning-bolts.git@master --upgrade
+
+In case you want to have full experience you can install all optional packages at once
+
+.. code-block:: bash
+
+   pip install pytorch-lightning-bolts["extra"]
+


### PR DESCRIPTION
## What does this PR do?
This is only a suggestion to add an installation guide on the home page so that users know exactly where to access from the home page first.

![tmp](https://user-images.githubusercontent.com/20610905/104079299-b06c6380-5265-11eb-9ecb-7711d159f8a0.png)

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
