### PR TITLE
Remove README from docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,15 +54,15 @@ github_repo = project
 
 # -- Project documents -------------------------------------------------------
 # export the READme
-with open(os.path.join(PATH_ROOT, 'README.md'), 'r') as fp:
-    readme = fp.read()
-# TODO: temp fix removing SVG badges and GIF, because PDF cannot show them
-readme = re.sub(r'(\[!\[.*\))', '', readme)
-readme = re.sub(r'(!\[.*.gif\))', '', readme)
-for dir_name in (os.path.basename(p) for p in glob.glob(os.path.join(PATH_ROOT, '*')) if os.path.isdir(p)):
-    readme = readme.replace('](%s/' % dir_name, '](%s/%s/' % (PATH_ROOT, dir_name))
-with open('readme.md', 'w') as fp:
-    fp.write(readme)
+# with open(os.path.join(PATH_ROOT, 'README.md'), 'r') as fp:
+#     readme = fp.read()
+# # TODO: temp fix removing SVG badges and GIF, because PDF cannot show them
+# readme = re.sub(r'(\[!\[.*\))', '', readme)
+# readme = re.sub(r'(!\[.*.gif\))', '', readme)
+# for dir_name in (os.path.basename(p) for p in glob.glob(os.path.join(PATH_ROOT, '*')) if os.path.isdir(p)):
+#     readme = readme.replace('](%s/' % dir_name, '](%s/%s/' % (PATH_ROOT, dir_name))
+# with open('readme.md', 'w') as fp:
+#     fp.write(readme)
 
 # copy all documents from GH templates like contribution guide
 for md in glob.glob(os.path.join(PATH_ROOT, '.github', '*.md')):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,6 @@ import builtins
 import glob
 import inspect
 import os
-import re
 import shutil
 import sys
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -110,7 +110,6 @@ Indices and tables
 .. toctree::
    :hidden:
 
-   readme
    api/pl_bolts.callbacks
    api/pl_bolts.datamodules
    api/pl_bolts.datasets


### PR DESCRIPTION
## What does this PR do?
This is also a suggestion to remove readme from the docs. I believe no one really sees this ugly readme (as shown in below image) on the docs... Also, readme is not linked from anywhere on the docs, so I'm sure anyone doen't look at this readme page... 
https://pytorch-lightning-bolts.readthedocs.io/en/latest/readme.html

![tmp](https://user-images.githubusercontent.com/20610905/104080034-30e09380-5269-11eb-8868-d2e3b824ab25.png)

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
