### PR TITLE
fixes DQN run_n_episodes using the wrong environment variable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the end of batch size mismatch ([#389](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/389))
 - Fixed `batch_size` parameter for DataModules remaining ([#344](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/344))
 - Fixed CIFAR `num_samples` ([#432](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/432))
+- Fixed DQN `run_n_episodes` using the wrong environment variable ([#525](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/525))
 
 ## [0.2.5] - 2020-10-12
 

--- a/pl_bolts/models/rl/dqn_model.py
+++ b/pl_bolts/models/rl/dqn_model.py
@@ -171,7 +171,7 @@ class DQN(pl.LightningModule):
             while not done:
                 self.agent.epsilon = epsilon
                 action = self.agent(episode_state, self.device)
-                next_state, reward, done, _ = self.env.step(action[0])
+                next_state, reward, done, _ = env.step(action[0])
                 episode_state = next_state
                 episode_reward += reward
 


### PR DESCRIPTION
## What does this PR do?
DQN's `run_n_episodes` method, which is used by `test_step` for testing the agent, uses the object's environment `self.env` and not its argument `env` to run the simulation steps. It resets `env` but takes simulation steps in `self.env`. 

As a result, the testing stats are wrong because the wrong environment is used by the agent and a different environment is being reset after each episode

Fixes #516 

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
