### PR TITLE
fix custom gamma in rl

### DIFF
--- a/pl_bolts/models/rl/double_dqn_model.py
+++ b/pl_bolts/models/rl/double_dqn_model.py
@@ -56,7 +56,7 @@ class DoubleDQN(DQN):
         """
 
         # calculates training loss
-        loss = double_dqn_loss(batch, self.net, self.target_net)
+        loss = double_dqn_loss(batch, self.net, self.target_net, self.gamma)
 
         if self.trainer.use_dp or self.trainer.use_ddp2:
             loss = loss.unsqueeze(0)

--- a/pl_bolts/models/rl/dqn_model.py
+++ b/pl_bolts/models/rl/dqn_model.py
@@ -270,7 +270,7 @@ class DQN(pl.LightningModule):
         """
 
         # calculates training loss
-        loss = dqn_loss(batch, self.net, self.target_net)
+        loss = dqn_loss(batch, self.net, self.target_net, self.gamma)
 
         if self.trainer.use_dp or self.trainer.use_ddp2:
             loss = loss.unsqueeze(0)

--- a/pl_bolts/models/rl/per_dqn_model.py
+++ b/pl_bolts/models/rl/per_dqn_model.py
@@ -114,7 +114,7 @@ class PERDQN(DQN):
         indices = indices.cpu().numpy()
 
         # calculates training loss
-        loss, batch_weights = per_dqn_loss(samples, weights, self.net, self.target_net)
+        loss, batch_weights = per_dqn_loss(samples, weights, self.net, self.target_net, self.gamma)
 
         if self.trainer.use_dp or self.trainer.use_ddp2:
             loss = loss.unsqueeze(0)


### PR DESCRIPTION
## What does this PR do?

I didn't make an issue as the bug seems to be obvious. 
So far in a few rl models, custom gamma could be set in __init__ but then was not passed to loss computation function.
This PR fixes it.

Fixes # (issue)

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
