### PR TITLE
Update basic_ae_module.py

### DIFF
--- a/pl_bolts/models/autoencoders/basic_ae/basic_ae_module.py
+++ b/pl_bolts/models/autoencoders/basic_ae/basic_ae_module.py
@@ -27,7 +27,7 @@ class AE(pl.LightningModule):
         ae = AE()
 
         # pretrained on cifar10
-        ae = AE.from_pretrained('cifar10-resnet18')
+        ae = AE(input_height=32).from_pretrained('cifar10-resnet18')
     """
 
     pretrained_urls = {


### PR DESCRIPTION
`AE` class instantiation is necessary to load pretrained model, as from_pretrained is not a static method.

## What does this PR do?
It updates a docstring in the basic_ae_module for `AE` class, which corrects the required way to instantiate a pretrained autoencoder for cifar.
<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
