### PR TITLE
Correct num_rows calculation in LatentDimInterpolator callback

### DIFF
--- a/pl_bolts/callbacks/variational.py
+++ b/pl_bolts/callbacks/variational.py
@@ -67,7 +67,7 @@ class LatentDimInterpolator(Callback):
             )
             images = torch.cat(images, dim=0)  # type: ignore[assignment]
 
-            num_rows = int(math.sqrt(self.steps))
+            num_rows = self.steps
             grid = torchvision.utils.make_grid(images, nrow=num_rows, normalize=self.normalize)
             str_title = f'{pl_module.__class__.__name__}_latent_space'
             trainer.logger.experiment.add_image(str_title, grid, global_step=trainer.global_step)

--- a/pl_bolts/callbacks/variational.py
+++ b/pl_bolts/callbacks/variational.py
@@ -1,4 +1,3 @@
-import math
 from typing import List
 
 import numpy as np

--- a/pl_bolts/callbacks/variational.py
+++ b/pl_bolts/callbacks/variational.py
@@ -67,8 +67,7 @@ class LatentDimInterpolator(Callback):
             )
             images = torch.cat(images, dim=0)  # type: ignore[assignment]
 
-            num_images = (self.range_end - self.range_start)**2
-            num_rows = int(math.sqrt(num_images))
+            num_rows = int(math.sqrt(self.steps))
             grid = torchvision.utils.make_grid(images, nrow=num_rows, normalize=self.normalize)
             str_title = f'{pl_module.__class__.__name__}_latent_space'
             trainer.logger.experiment.add_image(str_title, grid, global_step=trainer.global_step)


### PR DESCRIPTION
## What does this PR do?
It corrects the calculation of num_rows in the LatentDimInterpolator callback.
Instead of using the range [range_start, range_end] num_rows is calculated based on the number of steps.

Fixes https://github.com/PyTorchLightning/pytorch-lightning-bolts/issues/571

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
