### PR TITLE
Fix BYOL moving average update

### DIFF
--- a/pl_bolts/callbacks/byol_updates.py
+++ b/pl_bolts/callbacks/byol_updates.py
@@ -69,5 +69,4 @@ class BYOLMAWeightUpdate(Callback):
             online_net.named_parameters(),  # type: ignore[union-attr]
             target_net.named_parameters()  # type: ignore[union-attr]
         ):
-            if 'weight' in name:
-                target_p.data = self.current_tau * target_p.data + (1 - self.current_tau) * online_p.data
+            target_p.data = self.current_tau * target_p.data + (1 - self.current_tau) * online_p.data


### PR DESCRIPTION
No longer exclude biases from the moving average update in BYOL. See discussion on #440

## What does this PR do?

Fixes the BYOL moving average callback to update all parameters, no longer excluding biases, to better match the original paper

Fixes #440

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
