### PR TITLE
[Issue #578] Remove dependency of imagenet_dataset.py on torch._six

### DIFF
--- a/pl_bolts/datasets/imagenet_dataset.py
+++ b/pl_bolts/datasets/imagenet_dataset.py
@@ -1,6 +1,7 @@
 import gzip
 import hashlib
 import os
+import sys
 import shutil
 import tarfile
 import tempfile
@@ -9,10 +10,11 @@ from contextlib import contextmanager
 
 import numpy as np
 import torch
-from torch._six import PY37
 
 from pl_bolts.utils import _TORCHVISION_AVAILABLE
 from pl_bolts.utils.warnings import warn_missing_pkg
+
+PY3 = sys.version_info[0] == 3
 
 if _TORCHVISION_AVAILABLE:
     from torchvision.datasets import ImageNet
@@ -252,7 +254,7 @@ def extract_archive(from_path, to_path=None, remove_finished=False):
     elif _is_targz(from_path):
         with tarfile.open(from_path, 'r:gz') as tar:
             tar.extractall(path=to_path)
-    elif _is_tarxz(from_path) and PY37:
+    elif _is_tarxz(from_path) and PY3:
         # .tar.xz archive only supported in Python 3.x
         with tarfile.open(from_path, 'r:xz') as tar:
             tar.extractall(path=to_path)

--- a/pl_bolts/datasets/imagenet_dataset.py
+++ b/pl_bolts/datasets/imagenet_dataset.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 
 import numpy as np
 import torch
-from torch._six import PY3
+from torch._six import PY37
 
 from pl_bolts.utils import _TORCHVISION_AVAILABLE
 from pl_bolts.utils.warnings import warn_missing_pkg
@@ -252,7 +252,7 @@ def extract_archive(from_path, to_path=None, remove_finished=False):
     elif _is_targz(from_path):
         with tarfile.open(from_path, 'r:gz') as tar:
             tar.extractall(path=to_path)
-    elif _is_tarxz(from_path) and PY3:
+    elif _is_tarxz(from_path) and PY37:
         # .tar.xz archive only supported in Python 3.x
         with tarfile.open(from_path, 'r:xz') as tar:
             tar.extractall(path=to_path)


### PR DESCRIPTION
As of T[orch PR #46579](https://github.com/pytorch/pytorch/pull/49486/commits/0ebe248171623a98b1bb8389354b2067ca9377a3), it is no longer possible to import PY3 from torch._six

This small change simply removes the dependency on torch._six for checking if Python 3 is used.

Fixes #578 